### PR TITLE
feat: add createdAt support for custom expense dates and UI scroll fixes

### DIFF
--- a/src/app/core/models/expenses.model.ts
+++ b/src/app/core/models/expenses.model.ts
@@ -18,7 +18,7 @@ export interface ExpenseRequest {
   description: string;
   total: number;
   currency: string;
-  date?: string;
+  createdAt?: string;
   paidBy: ExpenseUser[];
   splits: ExpenseUser[];
 }

--- a/src/app/features/auth/login/login.component.scss
+++ b/src/app/features/auth/login/login.component.scss
@@ -2,13 +2,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
-  padding: 1rem;
+  height: 100dvh;
   background-color: var(--app-bg);
+  overflow: hidden;
 }
 
 .login-container {
   width: 100%;
+  max-width: 400px;
+  padding: 0 1rem;
+  overflow: hidden;
 
   mat-card {
     width: 100%;
@@ -23,6 +26,7 @@
     transition:
       background-color 0.3s ease,
       color 0.3s ease;
+    overflow: hidden;
   }
 
   .logo {

--- a/src/app/features/auth/register/register.component.scss
+++ b/src/app/features/auth/register/register.component.scss
@@ -1,8 +1,10 @@
 :host {
-  display: block;
-  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100dvh;
   background-color: var(--app-bg);
-  padding: 0;
+  overflow: hidden;
 }
 
 .register-screen {

--- a/src/app/features/expenses/expense-form/expense-form.component.html
+++ b/src/app/features/expenses/expense-form/expense-form.component.html
@@ -57,7 +57,7 @@
 
   <app-footer
     [calendarOnly]="true"
-    [date]="expenseForm.value.date"
+    [date]="expenseCreatedAtForFooter"
     (dateChange)="setExpenseDate($event)"
   ></app-footer>
 </div>

--- a/src/app/features/expenses/expense-form/expense-form.component.scss
+++ b/src/app/features/expenses/expense-form/expense-form.component.scss
@@ -25,7 +25,7 @@
   padding: 24px 16px;
   gap: 32px;
   background-color: var(--app-bg);
-  min-height: 100vh;
+  min-height: auto;
 }
 
 .expense-header-wrapper {

--- a/src/app/features/expenses/expense-form/expense-form.component.ts
+++ b/src/app/features/expenses/expense-form/expense-form.component.ts
@@ -58,7 +58,7 @@ export class ExpenseFormComponent implements OnInit {
     description: ['', Validators.required],
     total: [null, [Validators.required, Validators.min(0.01)]],
     currency: ['ARS', Validators.required],
-    date: [new Date(), Validators.required],
+    createdAt: [new Date(), Validators.required],
   });
 
   get members(): GroupMember[] {
@@ -124,17 +124,19 @@ export class ExpenseFormComponent implements OnInit {
       return;
     }
 
-    const { description, currency, date } = this.expenseForm.value;
+    const { description, currency, createdAt } = this.expenseForm.value;
+
     let isoDate: string | undefined;
-    if (typeof date === 'string') {
-      const [year, month, day] = date.split('-').map(Number);
+    if (typeof createdAt === 'string') {
+      const [year, month, day] = createdAt.split('-').map(Number);
       const localDate = new Date(year, month - 1, day, 12, 0, 0);
       isoDate = localDate.toISOString();
-    } else if (date instanceof Date) {
-      isoDate = date.toISOString();
+    } else if (createdAt instanceof Date) {
+      isoDate = createdAt.toISOString();
     } else {
       isoDate = undefined;
     }
+
     const total = Number(this.expenseForm.value.total);
     const groupMembers = this.group.members.map((m) => m.userId);
     const splits = this.buildSplits(groupMembers, total);
@@ -151,7 +153,7 @@ export class ExpenseFormComponent implements OnInit {
       description,
       total,
       currency,
-      date: isoDate,
+      createdAt: isoDate,
       paidBy: [{ userId: selectedPayer.userId, amount: total }],
       splits,
     };
@@ -239,14 +241,14 @@ export class ExpenseFormComponent implements OnInit {
     void this.router.navigate(['/groups', this.groupId]);
   }
 
-  get expenseDateForFooter(): Date {
-    const val = this.expenseForm.value.date;
+  get expenseCreatedAtForFooter(): Date {
+    const val = this.expenseForm.value.createdAt;
     if (val instanceof Date) return val;
     if (typeof val === 'string') return new Date(val);
     return new Date();
   }
 
-  setExpenseDate(date: Date) {
-    this.expenseForm.get('date')?.setValue(date);
+  setExpenseDate(createdAt: Date) {
+    this.expenseForm.get('createdAt')?.setValue(createdAt);
   }
 }

--- a/src/app/features/expenses/expenses/expenses.component.ts
+++ b/src/app/features/expenses/expenses/expenses.component.ts
@@ -28,7 +28,8 @@ export class ExpensesComponent {
     const map = new Map<string, Expense[]>();
 
     for (const exp of this.expenses) {
-      const month = new Date(exp.createdAt).toLocaleString('default', {
+      const date = new Date(exp.createdAt);
+      const month = date.toLocaleString('default', {
         month: 'long',
       });
       if (!map.has(month)) {

--- a/src/app/features/groups/group-form/group-form.component.scss
+++ b/src/app/features/groups/group-form/group-form.component.scss
@@ -34,7 +34,7 @@
   padding: 24px 16px;
   gap: 32px;
   background-color: var(--app-bg);
-  min-height: 100vh;
+  min-height: auto;
 }
 
 .field-row {

--- a/src/app/layouts/app-layout.component.scss
+++ b/src/app/layouts/app-layout.component.scss
@@ -1,6 +1,14 @@
+.layout-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+}
+
 .main-content-bg {
+  flex: 1;
+  overflow-y: auto;
   background-color: var(--app-bg);
-  min-height: 100vh;
   padding: 1rem;
   transition: background-color 0.3s ease;
 }

--- a/src/app/layouts/app-layout.component.ts
+++ b/src/app/layouts/app-layout.component.ts
@@ -11,10 +11,12 @@ import { FooterComponent } from '@app/features/footer/footer.component';
   selector: 'app-layout',
   imports: [RouterOutlet, FooterComponent],
   template: `
-    <main class="main-content-bg">
-      <router-outlet></router-outlet>
-    </main>
-    <app-footer></app-footer>
+    <div class="layout-wrapper">
+      <main class="main-content-bg">
+        <router-outlet></router-outlet>
+      </main>
+      <app-footer></app-footer>
+    </div>
   `,
   styleUrls: ['./app-layout.component.scss'],
 })

--- a/src/app/layouts/fullscreen-layout.component.scss
+++ b/src/app/layouts/fullscreen-layout.component.scss
@@ -1,0 +1,5 @@
+.fullscreen-wrapper {
+  height: 100dvh;
+  overflow-y: auto;
+  display: block;
+}

--- a/src/app/layouts/fullscreen-layout.component.ts
+++ b/src/app/layouts/fullscreen-layout.component.ts
@@ -5,6 +5,11 @@ import { RouterOutlet } from '@angular/router';
   standalone: true,
   selector: 'fullscreen-layout',
   imports: [RouterOutlet],
-  template: `<router-outlet></router-outlet>`,
+  template: `
+    <div class="fullscreen-wrapper">
+      <router-outlet></router-outlet>
+    </div>
+  `,
+  styleUrls: ['./fullscreen-layout.component.scss'],
 })
 export class FullscreenLayoutComponent {}

--- a/src/app/shared/styles/dialog-common.scss
+++ b/src/app/shared/styles/dialog-common.scss
@@ -1,9 +1,10 @@
 .dialog-container {
-  min-height: 100%;
+  height: 100dvh;
   background-color: var(--app-surface);
   display: flex;
   flex-direction: column;
-  padding: 16px;
+  padding: 16px 12px;
+  overflow: hidden;
 }
 
 .header {
@@ -32,11 +33,12 @@ mat-nav-list {
   flex-direction: column;
   gap: 12px;
   flex-grow: 1;
+  overflow: auto;
 }
 
 mat-list-item {
   cursor: pointer;
-  padding: 16px;
+  padding: 12px 16px;
   border-radius: var(--app-radius);
   background-color: var(--app-surface);
   box-shadow: 0 1px 2px rgba(var(--app-text-rgb), 0.05);
@@ -66,4 +68,9 @@ mat-list-item {
 :root ::ng-deep .mat-mdc-dialog-surface {
   background-color: var(--app-surface) !important;
   border-radius: 0 !important;
+}
+
+:root ::ng-deep .mat-mdc-dialog-container {
+  max-height: 100dvh;
+  overflow: hidden;
 }


### PR DESCRIPTION
- Implemented support to send `createdAt` when creating expenses
- Allows loading old expenses with correct date
- Fixed scroll issues on multiple screens (updated SCSS styles)
